### PR TITLE
Ci/workflow reliability hardening

### DIFF
--- a/.github/workflows/website-monitor.yml
+++ b/.github/workflows/website-monitor.yml
@@ -50,14 +50,18 @@ jobs:
             local fetched_content=""
             local fetched_code=""
             local response_body_file=""
+            local curl_exit=0
 
             response_body_file=$(mktemp)
-            if fetched_code=$(curl -sS --fail --max-time 15 --retry 2 -o "$response_body_file" -w "%{http_code}" "$target_url"); then
+            fetched_code=$(curl -sS --fail --max-time 15 --retry 2 --retry-all-errors -o "$response_body_file" -w "%{http_code}" "$target_url") || curl_exit=$?
+            if [ "$curl_exit" -eq 0 ]; then
               fetched_content=$(cat "$response_body_file")
             else
-              echo "Warning: failed to fetch content from $target_url"
+              echo "Warning: failed to fetch content from $target_url (curl exit code: $curl_exit, HTTP status: ${fetched_code:-unknown})"
               fetched_content=""
-              fetched_code="000"
+              if [ -z "$fetched_code" ]; then
+                fetched_code="000"
+              fi
             fi
             rm -f "$response_body_file"
 


### PR DESCRIPTION
This PR improves the reliability and safety of the `website-monitor` GitHub Actions workflow without changing its functional behavior.

**Changes**
- Upgraded `actions/checkout` to `@v4` for consistency.
- Added `concurrency` to prevent overlapping scheduled runs.
- Added `timeout-minutes: 10` to avoid stuck jobs.
- Hardened `curl` calls with retries, timeout, and fail handling to prevent transient network issues from crashing the job.
- Reduced workflow permissions by removing `pull-requests: write`.
- Bumped `slackapi/slack-github-action` from `v1.24.0` to `v1.27.1` (safe non-breaking v1 update).

**Verification**

- Deploy path unchanged (Pages + commit step intact).
- Slack failure gate logic unchanged.
- No concurrency conflicts with other workflows.
- Manual `workflow_dispatch` run recommended to validate end-to-end execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved website monitoring reliability with enhanced error handling and automatic retries for failed requests, including timeout management.
  * Extended result logging to include HTTP status codes for better visibility into monitored page health.

* **Chores**
  * Updated dependencies and workflow configurations for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->